### PR TITLE
GPU image with CI-CD

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -1,0 +1,45 @@
+name: CI-CD
+
+# TODO: Support for constructing .sif singularity image as artefact
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+
+jobs:
+  build-test-push:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: "${{github.event.inputs.branch_name}}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Setup Runner Build Tooling
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y --no-install-recommends build-essential
+
+      - name: Build Docker Images
+        run: |
+          make devenv-ubuntu_20_04-build && \
+          make devenv-ubuntu_20_04_nvidia_470-build
+
+      - name: Run Tests
+        run: |
+          make test
+
+      - name: Push Docker Images
+        run: |
+          make devenv-ubuntu_20_04-push && \
+          make devenv-ubuntu_20_04_nvidia_470-push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  pull_request:
+  #push:
+
+jobs:
+  run-tests:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: "${{github.event.inputs.branch_name}}"
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Setup Runner Build Tooling
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y --no-install-recommends build-essential
+
+      - name: Run Tests
+        run: |
+          make test-master

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,17 @@ DOCKER := DOCKER_BUILDKIT=1 docker
 SINGULARITY_CACHEDIR_DEVENV=$(PWD)/tmp/devenv/singularity-cache-dir
 
 VERSION=$(shell git describe --tags --dirty --always)
+VERSION_LATEST_MASTER=$(shell git describe --tags --abbrev=0 origin/master)
 
 all:
 	# Default is no action
 	@exit 0
+
+get-version:
+	@echo $(VERSION)
+
+get-version-latest-master:
+	 @echo $(VERSION_LATEST_MASTER)
 
 devenv-nvidia-cudnn-build:
 	# Image containing Nvidia cuDNN library
@@ -82,3 +89,26 @@ docker-clean-build-cache:
 singularity-clean-cache:
 	# Remove cached images, builds in Singularity
 	singularity cache clean
+
+test:
+	# Run tests on current version of docker image
+	$(MAKE) test-$(VERSION)
+
+test-master:
+	# Run tests on latest master image
+	docker pull clinicalgenomics/rdds:$(VERSION_LATEST_MASTER)
+	$(MAKE) test-$(VERSION_LATEST_MASTER)
+
+test-%:
+	# Target for executing tests on various docker image versions (default flavour)
+	$(DOCKER) run \
+	-i \
+	-l rdds-test:$* \
+	--rm=true \
+	-v $(PWD):/rdds \
+	--entrypoint 'bash' \
+	$(DOCKERHUB)/rdds:$* \
+	-c \
+	"export PYTHONPATH=/rdds/src && \
+	. /opt/conda/bin/activate && \
+	cd /rdds/src/tests && python3 -m pytest -v"

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,84 @@
 .PHONY: *
 
 DOCKERHUB=clinicalgenomics
+
+DEFAULT_DEVENV_OS_FLAVOUR=ubuntu_20_04
+
 DOCKER := DOCKER_BUILDKIT=1 docker
 SINGULARITY_CACHEDIR_DEVENV=$(PWD)/tmp/devenv/singularity-cache-dir
+
+VERSION=$(shell git describe --tags --dirty --always)
 
 all:
 	# Default is no action
 	@exit 0
 
-devenv-build:
-	# Build docker development image
-	$(DOCKER) build -t $(DOCKERHUB)/rdds --force-rm=true --rm=true --target devenv -f build/devenv/devenv.Dockerfile .
+devenv-nvidia-cudnn-build:
+	# Image containing Nvidia cuDNN library
+	$(DOCKER) build -t $(DOCKERHUB)/rdds-nvidia-cudnn:$(VERSION) --force-rm=true --rm=true -f build/devenv/nvidia-cudnn.Dockerfile .
 
-devenv-upload-clinicalgenomics-dockerhub:
+devenv-nvidia-cudnn-push:
+	$(DOCKER) push $(DOCKERHUB)/rdds-nvidia-cudnn:$(VERSION)
+
+devenv-%-build:
+	# Build docker development image
+	# Valid targets are:
+	# devenv-ubuntu_20_04-build (default)
+	# devenv-ubuntu_20_04_nvidia_470-build (GPU enabled)
+	$(eval DEVENV_IMAGE_SUFFIX=$(subst $(DEFAULT_DEVENV_OS_FLAVOUR),,$*))
+	$(DOCKER) build \
+	--build-arg="OS_FLAVOUR=$*" \
+	--build-arg="VERSION=$(VERSION)" \
+	-t $(DOCKERHUB)/rdds$(DEVENV_IMAGE_SUFFIX):$(VERSION) \
+	--force-rm=true \
+	--rm=true \
+	--target devenv \
+	-f build/devenv/devenv.Dockerfile .
+
+devenv-%-push:
 	# Upload docker image to clinicalgenomics organisation at dockerhub
 	# https://hub.docker.com/repository/docker/clinicalgenomics/rdds
-	$(DOCKER) push $(DOCKERHUB)/rdds
+	$(eval DEVENV_IMAGE_SUFFIX=$(subst $(DEFAULT_DEVENV_OS_FLAVOUR),,$*))
+	$(DOCKER) push $(DOCKERHUB)/rdds${DEVENV_IMAGE_SUFFIX}:$(VERSION)
 
-devenv-docker-sshd:
+devenv-%-docker-sshd:
 	# Start development environment locally
 	# Prefer the singularity option instead, since Docker docker mount
 	# is always root:root owned.
-	$(DOCKER) run -it -l $(DOCKERHUB)/rdds --rm=true -v $(PWD):/rdds -p 2150:2150 cg/rdds
+	$(eval DEVENV_IMAGE_SUFFIX=$(subst $(DEFAULT_DEVENV_OS_FLAVOUR),,$*))
+	$(DOCKER) run -it -l $(DOCKERHUB)/rdds${DEVENV_IMAGE_SUFFIX}:$(VERSION) --rm=true -v $(PWD):/rdds -p 2150:2150 $(DOCKERHUB)/rdds${DEVENV_IMAGE_SUFFIX}:$(VERSION)
 
 devenv-ssh:
 	# SSH into development container (local or tunneled)
 	chmod go-rw build/devenv/devenv-docker.rsakey
 	ssh -F build/devenv/devenv.sshconfig -oUserKnownHostsFile=/dev/null devenv
 
-devenv-convert-dockerimage-to-singularity:
+devenv-%-convert-dockerimage-to-singularity:
 	# Convert docker image to singularity format
+	$(eval DEVENV_IMAGE_SUFFIX=$(subst $(DEFAULT_DEVENV_OS_FLAVOUR),,$*))
 	mkdir -p tmp/devenv
-	docker save $(DOCKERHUB)/rdds -o tmp/devenv/rdds.tar
-	singularity build -F tmp/devenv/rdds.sif docker-archive://tmp/devenv/rdds.tar
-	rm -f tmp/devenv/rdds.tar
+	docker save $(DOCKERHUB)/rdds${DEVENV_IMAGE_SUFFIX}:$(VERSION) -o tmp/devenv/rdds${DEVENV_IMAGE_SUFFIX}-$(VERSION).tar
+	singularity build -F tmp/devenv/rdds${DEVENV_IMAGE_SUFFIX}-$(VERSION).sif docker-archive://tmp/devenv/rdds${DEVENV_IMAGE_SUFFIX}-$(VERSION).tar
+	rm -f tmp/devenv/rdds${DEVENV_IMAGE_SUFFIX}-$(VERSION).tar
 
-devenv-singularity-sshd:
+devenv-%-singularity-sshd:
 	# Start singularity development image locally
 	# Use --fakeroot to start as uid 0 and -w (required for sshd)
+	$(eval DEVENV_IMAGE_SUFFIX=$(subst $(DEFAULT_DEVENV_OS_FLAVOUR),,$*))
 	mkdir -p $(SINGULARITY_CACHEDIR_DEVENV)
-	SINGULARITY_CACHEDIR=$(SINGULARITY_CACHEDIR_DEVENV) singularity exec -w --fakeroot --no-home --cleanenv --contain --containall -B $(PWD):/rdds tmp/devenv/rdds.sif /entrypoint.sh
+	SINGULARITY_CACHEDIR=$(SINGULARITY_CACHEDIR_DEVENV) singularity exec --nv -w \
+	--fakeroot --no-home --cleanenv --contain --containall \
+	-B $(PWD):/rdds tmp/devenv/rdds${DEVENV_IMAGE_SUFFIX}-$(VERSION).sif /entrypoint.sh
 
 docker-clean-images:
 	# Remove all docker dangling images and stopped containers
 	docker system prune
+
+docker-clean-build-cache:
+	# Removes docker build cache (often very large)
+	docker builder prune
+	docker buildx prune
+
+singularity-clean-cache:
+	# Remove cached images, builds in Singularity
+	singularity cache clean

--- a/README-nvidia-gpu.md
+++ b/README-nvidia-gpu.md
@@ -1,0 +1,136 @@
+# Utilising NVIDIA GPUs in Containers
+
+This readme is about utilising GPU from inside of Docker and Singularity
+containers.
+
+It's targeting Tensorflow dependencies (CUDA, cuDNN libraries).
+In general, Tensorflow is only tested, compatible with a subset of Nvidia GPU
+drivers and related libraries. The Tensorflow GPU functionality
+is also coupled to these libraries at build time. Every Tensorflow version
+is only compatible with a specific Nvidia GPU Driver and accompanying libraries.
+
+Tensorflow `v2.12` has the following requirements:
+```
+NVIDIA® GPU drivers version 450.80.02 or higher.
+CUDA® Toolkit 11.8.
+cuDNN SDK 8.6.0.
+```
+
+See [tested GPU versions](https://www.tensorflow.org/install/source#gpu) for more information.
+
+## Host - Container Integration
+In general, the host kernel exposes the Nvidia GPU to the container OS.
+It's the host (Nvidia) kernel (driver) that determines what driver version
+to use.
+
+From inside the container, there's strictly no need to install the GPU driver
+itself, but the driver package often comes with an ecosystem that's required
+for other applications. Therefore, it's often less problematic to mirror
+the host Nvidia driver version into the container.
+
+However, ecosystem libraries related to the driver must match the Nvidia driver,
+both in the host OS and container.
+
+### A Note On Docker GPU Ecosystem
+Since we're targeting a SLURM environment, we cannot depend on
+Nvidia's GPU integration suite, `Nvidia Container Toolkit` and
+`Nvidia Container Runtime` which is a Docker-centered framework that solves GPU integration hassle.
+
+There are also Nvidia built GPU enabled docker images available upstream.
+However, basing our images on these Nvidia provided images would make it
+difficult to truly custom-build our ecosystem.
+
+### Downstream Libraries Depends On Nvidia GPU Driver
+Libraries such as Nvidia CUDA and Nvidia cuDNN are dependent on the Nvidia GPU
+Driver version.
+
+See [this compatibility matrix](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#deployment-consideration-forward)
+for more information.
+
+## Host Setup
+### Configuring Ubuntu 20.04
+#### ubuntu-drivers
+https://ubuntu.com/server/docs/nvidia-drivers-installation
+
+The preferred way is to install Nvidia GPU driver using the `ubuntu-drivers` tool.
+```
+ubuntu-drivers install nvidia:470
+```
+
+#### Ubuntu NVIDIA GPU Drivers Dist
+Installing (old) NVIDIA driver not available via the `ubuntu-drivers` utility,
+via APT utility.
+
+```
+Installing the NVIDIA driver manually means installing the
+correct kernel modules first, then installing the metapackage for the driver series.
+```
+
+Useful for customizing the install w.r.t Nvidia Driver - CUDA versions.
+https://ubuntu.com/server/docs/nvidia-drivers-installation
+
+Example
+```
+apt-get install -y linux-modules-nvidia-470-generic nvidia-driver-470
+```
+Should install `nvidia-driver-470, linux-modules-nvidia-470-5.15.0-86-generic`
+
+Be aware of `meta`-packages that install higher versions of nvidia drivers!
+Make sure to read in on the package details; `apt-cache show nvidia-driver-470`.
+
+#### NVIDIA Driver Repository
+Installing from .run scripts from Nvidia is also an alternative,
+but it's very cumbersome and prone to configuration errors.
+
+https://www.nvidia.com/en-us/drivers/unix/
+https://www.nvidia.com/en-us/drivers/unix/linux-amd64-display-archive/
+
+## Nvidia CUDA
+CUDA library is a development library to allow general purpose computing
+on Nvidia's GPUs.
+
+Nvidia provides a remote .deb Ubuntu installer.
+
+See [CUDA Quick Start Guide](https://docs.nvidia.com/cuda/cuda-quick-start-guide/index.html)
+for more information.
+
+## Nvidia cuDNN
+Nvidia CUDA Deep Neural Network (cuDNN) library is an optimized library
+for DNN applications on Nvidia GPUs.
+
+See [cuDNN Introduction](https://developer.nvidia.com/cudnn) and
+[cuDNN Linux Install Guide](https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html#installlinux-tar)
+for more information.
+
+Access to the library is "account-walled" by Nvidia.
+
+Since these tarballs are not ready accessible over HTTPS, there's a
+`clinicalgenomics` image built for CI/CD purposes, see
+[nvidia-cudnn.Dockerfile](build/devenv/nvidia-cudnn.Dockerfile).
+
+Downloading of the library can be done by accessing the
+[cuDNN archive](https://developer.nvidia.com/rdp/cudnn-archive), a full URL example:
+`https://developer.nvidia.com/compute/cudnn/secure/8.6.0/local_installers/11.8/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tar.xz`.
+
+There's a local deb installer too, but there it's not as easy to select install flavor
+as in the tarball case.
+
+## Installation Process
+0. Install Nvidia Driver to Host machine
+
+Install CUDA and cuDNN libraries in container, do;
+1. Install Nvidia GPU Driver
+2. Install CUDA
+3. Install cuDNN into CUDA library directory
+4. Setup `PATH`, `LD_LIBRARY_PATH` to allow access to tooling and dynamic linking:
+```
+export PATH=/usr/local/cuda-11.8/bin${PATH:+:${PATH}}
+export LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+```
+
+## Testing
+```
+cat /proc/driver/nvidia/version
+find / -name cuda* 2>/dev/null
+```
+and additionally run the [python GPU test script](build/devenv/gputest.py).

--- a/build/devenv/devenv.Dockerfile
+++ b/build/devenv/devenv.Dockerfile
@@ -1,12 +1,19 @@
+ARG OS_FLAVOUR
+ARG VERSION
+
+FROM clinicalgenomics/rdds-ubuntu-20.04-nvidia-470:${VERSION} AS ubuntu_20_04_nvidia_470
+# Placeholder to set stage label name
+
 # Ubuntu 20.04/AMD64
-FROM ubuntu@sha256:b795f8e0caaaacad9859a9a38fe1c78154f8301fdaf0872eaf1520d66d9c0b98 AS base
-
+FROM ubuntu@sha256:b795f8e0caaaacad9859a9a38fe1c78154f8301fdaf0872eaf1520d66d9c0b98 AS ubuntu_20_04
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Install OS deps
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y wget \
+    apt-get install -y wget
+
+FROM ${OS_FLAVOUR} as base
+# Install OS deps
+RUN apt-get install -y \
     xorg \
     xauth
 

--- a/build/devenv/gputest.py
+++ b/build/devenv/gputest.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+from os import environ
+from tensorflow.python.platform import build_info as build
+from tensorflow.python.client import device_lib
+
+print(environ)
+
+print(f"TF was built with CUDA v{build.build_info['cuda_version']}")
+
+print(device_lib.list_local_devices())
+
+devices = tf.config.list_physical_devices('GPU')
+
+assert len(devices) > 0, 'Expected to find a GPU device but found none'

--- a/build/devenv/nvidia-cudnn.Dockerfile
+++ b/build/devenv/nvidia-cudnn.Dockerfile
@@ -1,0 +1,11 @@
+# Image containing cuDNN drivers not readily accessible over Internet due to Nvidia login-wall.
+# In order to build this docker image, you must login to Nvidia homepage and
+# download the tarballs. Then run the appropriate Makefile target.
+# See: https://developer.nvidia.com/cudnn
+# and https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html#installlinux-tar
+FROM scratch
+
+WORKDIR /opt/cudnn
+
+# https://developer.nvidia.com/compute/cudnn/secure/8.6.0/local_installers/11.8/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tar.xz
+COPY build/devenv/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tar.xz .

--- a/build/devenv/ubuntu-20.04-nvidia-470.Dockerfile
+++ b/build/devenv/ubuntu-20.04-nvidia-470.Dockerfile
@@ -1,0 +1,36 @@
+# Ubuntu 20.04/AMD64
+FROM ubuntu@sha256:b795f8e0caaaacad9859a9a38fe1c78154f8301fdaf0872eaf1520d66d9c0b98 AS ubuntu
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y wget \
+    kmod
+
+WORKDIR /tmp
+
+# Install NVIDIA GPU driver
+# Additionally install meta package linux-modules-nvidia-520-generic as well?
+RUN apt-get install --no-install-recommends -y nvidia-driver-470=470.199.02-0ubuntu0.20.04.1
+
+# Install NVIDIA CUDA library
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb && \
+  dpkg -i cuda-keyring_1.1-1_all.deb && \
+  apt-get update && \
+  apt-get install -y cuda-libraries-11-8 && \
+  rm *.deb
+
+# Install NVIDIA cuDNN libraries into CUDA dir (must be compatible with Nvidia Driver, CUDA versions)
+COPY --from=clinicalgenomics/rdds-nvidia-cudnn:draft /opt/cudnn/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tar.xz .
+RUN tar -xf cudnn-*.tar.xz && \
+  mkdir -p /usr/local/cuda/include && \
+  cp cudnn-*-archive/include/cudnn*.h /usr/local/cuda/include  && \
+  cp -P cudnn-*-archive/lib/libcudnn* /usr/local/cuda/lib64  && \
+  chmod a+r /usr/local/cuda/include/cudnn*.h /usr/local/cuda/lib64/libcudnn*  && \
+  rm *.tar.xz
+
+RUN \
+  echo "# Source this prior to initialising conda environment" > /opt/init-cuda-cudnn && \
+  echo "export PATH=/usr/local/cuda-11.8/bin:\$PATH" >> /opt/init-cuda-cudnn && \
+  echo "export LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64:\$LD_LIBRARY_PATH" >> /opt/init-cuda-cudnn


### PR DESCRIPTION
Add GPU enabled docker image as a reference and starting point for GPU development on Hasta.

Add github workflow for building images.
CI-CD currently failing due to conda env bug: https://github.com/Clinical-Genomics/rdds/issues/24