### PR TITLE
Lowercase all words in VCF

### DIFF
--- a/src/rdds/lib/tf/text_preprocessing_layer.py
+++ b/src/rdds/lib/tf/text_preprocessing_layer.py
@@ -19,15 +19,19 @@ class TextPreprocessingLayer(tf.Module):
         tf.Module.__init__(self, name='TextPreprocessing')
         self._splitter: tftext.Splitter = tftext.RegexSplitter(split_regex=split_regex)
 
+    def _process_tensor(self, tensor: tf.RaggedTensor) -> tf.RaggedTensor:
+        tensor = tf.strings.lower(tensor)
+        return self._splitter.split(tensor)
+
     def __call__(self, *ragged_tensors: Union[tf.RaggedTensor, Tuple[tf.RaggedTensor]]) -> Union[tf.RaggedTensor, Tuple[tf.RaggedTensor]]:
         """
         Apply text preprocessing to input tensor x
         :param ragged_tensors: RaggedTensor or Tuple[RaggedTensor]
         :return: Preprocessed data as RaggedTensor or Tuple[RaggedTensor]
         """
-        if len(tensors) == 1:
-            return self._splitter.split(ragged_tensors[0])
+        if isinstance(ragged_tensors, tuple) and len(ragged_tensors) == 1:
+            return self._process_tensor(ragged_tensors[0])
         processed_tensors = tuple()
-        for tensor in tensors:
-            processed_tensors += (self._splitter.split(ragged_tensors), )
+        for ragged_tensor in ragged_tensors:
+            processed_tensors += (self._process_tensor(ragged_tensor), )
         return processed_tensors

--- a/src/tests/tf/test_text_vectorization_layer.py
+++ b/src/tests/tf/test_text_vectorization_layer.py
@@ -19,7 +19,7 @@ def test_text_vectorization_layer(word_dataset, work_dir):
     model.compile()
     # THEN expect the dictionary to contain the words in the dataset
     y = model.predict(['nicely'])
-    assert 'Some' in text_vectorization_layer._vocabulary_layer.get_vocabulary()
+    assert 'some' in text_vectorization_layer._vocabulary_layer.get_vocabulary()
 
     # THEN expect the embeddings to match expected shape
     assert isinstance(text_vectorization_layer.embeddings, list)


### PR DESCRIPTION
This PR will make all data in VCF to be lower-case when fed as input to ML model,
in the text pre-processing step.

The main reason for doing this is to make the vocabulary case-insensitive
(smaller vocabulary) as well as avoiding the scenario when
variant meta data is multi-case;

`Pathogenic` vs `pathogenic`

I don't want these two words to be separately encoded in the embeddings,
risk of model overfitting to upper-case words and ignoring variants
in lower-case, and vice versa.

AFAIK I don't see any risk (mixups, data-loss, .. ?) in doing this.
Feel free to let me know if I'm missing anything here.
