### PR TITLE
docker devenv: Run APT update prior to install

### DIFF
--- a/build/devenv/devenv.Dockerfile
+++ b/build/devenv/devenv.Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
 
 FROM ${OS_FLAVOUR} as base
 # Install OS deps
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
     xorg \
     xauth
 


### PR DESCRIPTION
Signed-off-by: Tor Björgen <tor.bjorgen@scilifelab.se>
