### PR TITLE
CI-CD workflow: Split docker image build to separate runners

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -8,7 +8,7 @@ on:
       - v*
 
 jobs:
-  build-test-push:
+  build-devenv-docker-image:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -28,17 +28,44 @@ jobs:
           sudo apt-get update && \
           sudo apt-get install -y --no-install-recommends build-essential
 
-      - name: Build Docker Images
+      - name: Build docker devenv image
         run: |
-          make devenv-ubuntu_20_04-build && \
-          make base-ubuntu-20-04-nvidia-build && \
-          make devenv-ubuntu_20_04_nvidia-build
+          make devenv-ubuntu_20_04-build
 
       - name: Run Tests
         run: |
           make test
 
-      - name: Push Docker Images
+      - name: Push Docker Image
         run: |
-          make devenv-ubuntu_20_04-push && \
+          make devenv-ubuntu_20_04-push
+
+  build-devenv-nvidia-docker-image:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    needs: build-devenv-docker-image
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: "${{github.event.inputs.branch_name}}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Setup Runner Build Tooling
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y --no-install-recommends build-essential
+
+      - name: Build Docker devenv GPU images
+        run: |
+          make base-ubuntu-20-04-nvidia-build && \
+          make devenv-ubuntu_20_04_nvidia-build
+
+      - name: Push Docker Image
+        run: |
           make devenv-ubuntu_20_04_nvidia-push


### PR DESCRIPTION
Otherwise, runner runs out of disk space.

Signed-off-by: Tor Björgen <tor.bjorgen@scilifelab.se>
