### PR TITLE
Increase Github workflow test duration to max 45 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   run-tests:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Signed-off-by: Tor Björgen <tor.bjorgen@scilifelab.se>
