### PR TITLE
vrs: NF dataset: sort stable on rank index

### DIFF
--- a/src/rdds/variant_rank_score/inference_exploration/mivmir_nextflow/build_analyze_mivmir_nextflow_dataset.py
+++ b/src/rdds/variant_rank_score/inference_exploration/mivmir_nextflow/build_analyze_mivmir_nextflow_dataset.py
@@ -315,9 +315,9 @@ def compute_causative_rank(hd5_file_path: str,
             continue
         # Now causative variant is found across both datasets, compute the rank
         causative_variant_id = common_causative_variant_ids[0]
-        rank_mivmir: int = case_variants.sort_values('score_mivmir', ascending=False).index.get_loc(causative_variant_id)
-        rank_gicam: int = case_variants.sort_values('score_gicam', ascending=False).index.get_loc(causative_variant_id)
-        rank_genmod: Union[int, List[bool]] = case_variants_by_genmod.sort_values('score_legacy_genmod', ascending=False).index.get_loc(causative_variant_id)
+        rank_mivmir: int = case_variants.sort_values('score_mivmir', ascending=False, kind='stable').index.get_loc(causative_variant_id)
+        rank_gicam: int = case_variants.sort_values('score_gicam', ascending=False, kind='stable').index.get_loc(causative_variant_id)
+        rank_genmod: Union[int, List[bool]] = case_variants_by_genmod.sort_values('score_legacy_genmod', ascending=False, kind='stable').index.get_loc(causative_variant_id)
         if not isinstance(rank_genmod, (int, float)):  # ... it's a list of boolean indexes, [True, False, ... ]
             # In case genmod data contains multiple, causative variants (in this case), select the highest score
             # This is the first position in the index, starting a 0 and counting, which matches TRUE


### PR DESCRIPTION
# 1
Rerun rank computation on

/opt/home/tor.bjorgen/repos/cg/rdds0/tmp/variant-rank-score/outdir_v1.12.0-rc1-18-ge950d18-patfilt
/opt/home/tor.bjorgen/repos/cg/rdds0/tmp/variant-rank-score/outdir_v1.12.0-rc2-4_no_frq
and check that genmod rank scores are identical.

# 2
Also check why  
https://github.com/Clinical-Genomics/rdds/blob/master/src/rdds/variant_rank_score/inference_exploration/statfns.py#L151-L154
gives varying results even though plot data looks identical.


Signed-off-by: Tor Björgen <tor.bjorgen@scilifelab.se>
