### PR TITLE
381 override annotation keys

### DIFF
--- a/src/rdds/variant_rank_score/__main__.py
+++ b/src/rdds/variant_rank_score/__main__.py
@@ -113,8 +113,22 @@ subparser.add_argument('--pretrained_model_explainer_path', help='Path to VRS pr
 subparser.add_argument('--cpu_cores',
                        help='Number of CPU cores to allocate for processing',
                        default=os.cpu_count() - 1)
+subparser.add_argument('--explain_variant_score_threshold',
+                       help='Explain inference on variants with inference score >= threshold',
+                       default=None)
+subparser.add_argument('--override_vcf_input_keys',
+                       help='Use alternative VCF annotation key as model input, not using model default. [OLD_NAME:NEW_NAME],[...] ...',
+                       default=None)
 def predict_on_vcf(args):
     from .vcf_inference import predict_on_vcf
+    from .vcf_inference.parse_override_vcf_input_keys import parse_override_vcf_input_keys
+
+    override_vcf_input_keys = parse_override_vcf_input_keys(args.override_vcf_input_keys)
+    print(f"Overriding input VCF keys:\n{override_vcf_input_keys}")
+
+    explain_variant_score_threshold = float(args.explain_variant_score_threshold) if \
+        args.explain_variant_score_threshold is not None else None
+
     if '*' in args.vcf_file_path:
         # Globbing
         vcf_file_paths = glob(args.vcf_file_path)
@@ -127,7 +141,10 @@ def predict_on_vcf(args):
         predict_on_vcf(vrs_model_file_path=args.pretrained_model_path,
                        model_explainer_path=args.pretrained_model_explainer_path,
                        vcf_file_path=vcf_file_path,
-                       cpu_cores=int(args.cpu_cores))
+                       cpu_cores=int(args.cpu_cores),
+                       explain_variant_score_threshold=explain_variant_score_threshold,
+                       override_vcf_input_keys=override_vcf_input_keys
+                       )
 subparser.set_defaults(func=predict_on_vcf)
 
 subparser = subparsers.add_parser('post-train-explainer', help='Train explanations model from pretrained keras model')

--- a/src/rdds/variant_rank_score/model/model.py
+++ b/src/rdds/variant_rank_score/model/model.py
@@ -988,7 +988,8 @@ class VariantRankScoreModel:
     def score_variant(self,
                       variants: List[ParsableVariant],
                       explain_variant_score_threshold: float = 0.9,
-                      ignore_clinvar_uncertain_conflicting_annotations: bool = True) -> pd.DataFrame:
+                      ignore_clinvar_uncertain_conflicting_annotations: bool = True,
+                      override_vcf_input_keys: Dict[str, str] = None) -> pd.DataFrame:
         """
         Run model inference step on ParsableVariant instance.
         :param variants: The variants to score
@@ -996,6 +997,8 @@ class VariantRankScoreModel:
         :param ignore_clinvar_uncertain_conflicting_annotations: Drop CLINVAR_CLNSIG, CLINVAR_CLNREVSTAT annotation data
             in case CLNSIG field contains conflicting or uncertain keywords.
             If set to False, model will reduce inference score for conflicting or uncertain variants.
+        :param override_vcf_input_keys: Dict mapping of keys to override in case another VCF key is desired as
+            model input instead of standard model input naming in _generate_dataset_tensor_signature().
         :return: Rank scores, (0, 1), the higher the more pathogenic.
           Input-output order is preserved.
         """
@@ -1023,12 +1026,17 @@ class VariantRankScoreModel:
         input_dict: Dict[str, Union[List, tf.Tensor]] = {}
         for tensor_spec in model_input_data_spec:
             input_dict.update({tensor_spec.name: []})
+            if override_vcf_input_keys is not None and tensor_spec.name in override_vcf_input_keys.keys():
+                _LOGGER.info(f"Using {override_vcf_input_keys[tensor_spec.name]} as input instead of {tensor_spec.name}")
+                vcf_key = override_vcf_input_keys[tensor_spec.name]
+            else:
+                vcf_key = tensor_spec.name
             for variant in variants:
                 if tensor_spec.dtype == tf.string:
-                    str_data = get_str_feature(variant=variant, name=tensor_spec.name)
+                    str_data = get_str_feature(variant=variant, name=vcf_key)
                     if ignore_clinvar_uncertain_conflicting_annotations:
                         try:
-                            if 'CLINVAR' in tensor_spec.name:  # TODO: Issue 257
+                            if 'CLINVAR' in vcf_key:  # TODO: Issue 257
                                 clinvar_clnsig = str(variant.__getattribute__('CSQ_CLINVAR_CLNSIG')).lower()
                                 if 'uncertain' in clinvar_clnsig or 'conflicting' in clinvar_clnsig:
                                     str_data = b''
@@ -1036,7 +1044,7 @@ class VariantRankScoreModel:
                             pass
                     input_dict[tensor_spec.name].append(str_data)
                 elif tensor_spec.dtype == tf.float32:
-                    input_dict[tensor_spec.name].append(get_num_feature(variant=variant, name=tensor_spec.name))
+                    input_dict[tensor_spec.name].append(get_num_feature(variant=variant, name=vcf_key))
                 else:
                     raise ValueError(f'Unmapped input data dtype spec: {tensor_spec}')
             # Convert to Tensor
@@ -1058,6 +1066,8 @@ class VariantRankScoreModel:
             explanations_full[idx_scores_above_threshold, :] = self._model_explainer.shap_values(X=df_selected_variants_for_explanation.values,
                                                                                                  gc_collect=True)  # FIXME: Method call not supposed to be erroneous by typechecker
         explanations_df = pd.DataFrame(data=explanations_full, columns=self._features)
+        if override_vcf_input_keys is not None:
+            explanations_df.rename(columns=override_vcf_input_keys, inplace=True)
         result_df = pd.concat(objs=(pd.Series(pathogenicity_scores, name='pathogenicity_score'),
                                     explanations_df),
                               axis=1)

--- a/src/rdds/variant_rank_score/vcf_inference/parse_override_vcf_input_keys.py
+++ b/src/rdds/variant_rank_score/vcf_inference/parse_override_vcf_input_keys.py
@@ -1,0 +1,19 @@
+from typing import Dict
+
+
+def parse_override_vcf_input_keys(keys) -> Dict[str, str]:
+    """
+    Parse [OLD_KEY:NEW_KEY],[...],... syntax from cli to override model input annotations.
+    :param str: The complete string
+    :return: A dict where the key is the old vcf key, and value is the new vcf key
+    """
+    if keys is None:
+        return None
+    assert isinstance(keys, str), f'Expected keys to be a string but got {type(keys)} {keys}'
+    assert len(keys) > 0, 'Expected keys to not be empty string'
+    override_vcf_input_keys: dict[str, str] = dict()
+    key_value_pairs = keys.split(',')
+    for key_value_pair in key_value_pairs:
+        key, value = key_value_pair.split(':')
+        override_vcf_input_keys.update({key: value})
+    return override_vcf_input_keys

--- a/src/rdds/variant_rank_score/vcf_inference/predict_on_vcf.py
+++ b/src/rdds/variant_rank_score/vcf_inference/predict_on_vcf.py
@@ -2,6 +2,7 @@ import os
 import pandas as pd
 from cyvcf2 import Writer as VcfWriter
 import gc
+from typing import Dict
 
 from rdds.lib.logging import get_logger
 from .. import WORKDIR
@@ -17,7 +18,9 @@ def _subprocess_predict_on_vcf_part(vcf_file_path: str,
                                     model_explainer_path: str,
                                     subprocess_work_dir: str,
                                     variant_index_start: int,
-                                    variant_index_stop: int):
+                                    variant_index_stop: int,
+                                    explain_variant_score_threshold: float = None,
+                                    override_vcf_input_keys: Dict[str, str] = None):
     from ..model import VariantRankScoreModel
     vcf_reader = VCFReader(vcf_file_path)
     vcf_reader.add_info_to_header({'ID': 'MivmirScore',
@@ -52,7 +55,12 @@ def _subprocess_predict_on_vcf_part(vcf_file_path: str,
     vrs_model = VariantRankScoreModel()
     vrs_model.load_saved_model(keras_model_path=vrs_model_file_path,
                                model_explainer_path=model_explainer_path)
-    df: pd.DataFrame = vrs_model.score_variant(parsed_variants)
+    score_variant_kwargs = {'variants': parsed_variants}
+    if override_vcf_input_keys is not None:
+        score_variant_kwargs.update({'override_vcf_input_keys': override_vcf_input_keys})
+    if explain_variant_score_threshold is not None:
+        score_variant_kwargs.update({'explain_variant_score_threshold': explain_variant_score_threshold})
+    df: pd.DataFrame = vrs_model.score_variant(**score_variant_kwargs)
     for i, variant in enumerate(variants):
         df_i = df.iloc[i]
         variant.INFO['MivmirScore'] = f'{df_i.pathogenicity_score:.5F}'
@@ -75,19 +83,24 @@ def _subprocess_predict_on_vcf_part(vcf_file_path: str,
 def predict_on_vcf(vrs_model_file_path: str,
                    model_explainer_path: str,
                    vcf_file_path:str,
-                   cpu_cores: int):
+                   cpu_cores: int,
+                   explain_variant_score_threshold: float = None,
+                   override_vcf_input_keys: Dict[str, str] = None):
     """
     Run pre-trained model to annotate VCF with inferences.
     This method requires ~80GB RAM with default settings
 
     :param vrs_model_file_path: The path to the pretrained model
     :param model_explainer_path: The path to the saved model explainer
-    :param vcf_file_path:
-    :param cpu_cores:
+    :param vcf_file_path: Path to the VCF file
+    :param cpu_cores: Amount of cores to use
+    param override_vcf_input_keys: Override VCF input keys
     """
     fn_kwargs = {
         'vrs_model_file_path': vrs_model_file_path,
         'model_explainer_path': model_explainer_path,
+        'explain_variant_score_threshold': explain_variant_score_threshold,
+        'override_vcf_input_keys': override_vcf_input_keys
     }
     map_vcf(vcf_file_path=vcf_file_path,
             fn=_subprocess_predict_on_vcf_part,

--- a/src/tests/variant_rank_score/test_inference.py
+++ b/src/tests/variant_rank_score/test_inference.py
@@ -214,3 +214,63 @@ def test_inference_batch_composition(ignore_clinvar_uncertain_conflicting_annota
             d = d.dropna()
             err = np.sum(np.abs(d.values))
             assert np.isclose(err, 0.0, atol=1E-3), (column, d)
+
+
+@pt.mark.parametrize('override_vcf_input_keys',
+                     [
+                         'most_severe_consequence:foo',
+                         'Frq:foo,CADD:bar,most_severe_consequence:THE_consequence'
+                     ])
+def test_override_input_annotations(work_dir,
+                                    override_vcf_input_keys):
+    """
+    Test to verify that inference input annotations can be overridden by user.
+    """
+    # GIVEN a VCF as input
+    test_data_path = os.path.basename(TEST_DATA_PATH)
+    test_data_path = os.path.join(work_dir, test_data_path)
+    shutil.copyfile(TEST_DATA_PATH, test_data_path)
+    test_data_path_modified = test_data_path.replace('.vcf', '.mod.vcf')
+    shutil.copyfile(test_data_path, test_data_path_modified)
+
+    # WHEN configuring inference to use alternative inference VCF key as input, instead of default
+    # Edit keys in VCF
+    old_keys = []
+    new_keys = []
+    for overrides in override_vcf_input_keys.split(','):
+        old, new = overrides.split(':')
+        sp.check_call(f'sed -i \'s/{old}/{new}/g\' {test_data_path_modified}',
+                      shell=True,
+                      stderr=sp.STDOUT)
+        old_keys.append(old)
+        new_keys.append(new)
+
+    ## Run reference model
+    sp.check_call(f'python3 -m rdds.variant_rank_score predict-on-vcf \
+        --explain_variant_score_threshold 0.0 \
+        {test_data_path}',
+                  shell=True,
+                  stderr=sp.STDOUT)
+
+    sp.check_call(f'python3 -m rdds.variant_rank_score predict-on-vcf \
+        --explain_variant_score_threshold 0.0 \
+        --override_vcf_input_keys {override_vcf_input_keys} \
+        {test_data_path_modified}',
+                  shell=True,
+                  stderr=sp.STDOUT)
+
+    vcf_reader = VCFReader(test_data_path.replace('.vcf', '-predictions.vcf'))
+    variants = list(vcf_reader)
+
+    vcf_reader_alternative_annotation = VCFReader(test_data_path_modified.replace('.vcf', '-predictions.vcf'))
+    variants_alternative_annotation = list(vcf_reader_alternative_annotation)
+
+    for variant, variant_alternative_annotation in zip(variants, variants_alternative_annotation):
+        #  THEN expect identical behavior to non-modified VCF and default model inference
+        assert variant.INFO['MivmirScore'] == variant_alternative_annotation.INFO['MivmirScore'], (variant.ID)
+        # THEN expect that the explanations is also adjusted accordingly to new key
+        explanations = variant_alternative_annotation.INFO['MivmirExplanation']
+        for old_key in old_keys:
+            assert old_key not in explanations, (old_key, explanations)
+        for new_key in new_keys:
+            assert new_key in explanations, (new_key, explanations)


### PR DESCRIPTION
Allow user to override model default input key names in VCF,
so that it can allow for some flexibility in refactoring
the pipeline where it's running.
